### PR TITLE
Improve memory usage for mimetype

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.2 (2017-07-29)
+
+- Improved performance of `MimeTypeValidator` by not reading the entire file into memory. Since the algorithm used at https://golang.org/pkg/net/http/#DetectContentType considers at most the first 512 bytes, it made no sense reading the entire file.
+
 ## 1.1.1 (2017-06-05)
 
 - Fixed bug in `LengthInBytes` accepting invalid units (such as "1KBB","1MBB")

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,7 +2,7 @@
 
 ## 1.1.2 (2017-07-29)
 
-- Improved performance of `MimeTypeValidator` by not reading the entire file into memory. Since the algorithm used at https://golang.org/pkg/net/http/#DetectContentType considers at most the first 512 bytes, it made no sense reading the entire file.
+- Improved performance of `MimeTypeValidator` by not reading the entire file into memory. Since the algorithm used at https://golang.org/pkg/net/http/#DetectContentType considers at most the first 512 bytes, it makes no sense to get the entire bytes.
 
 ## 1.1.1 (2017-06-05)
 

--- a/validator/mimetype.go
+++ b/validator/mimetype.go
@@ -2,7 +2,6 @@ package validator
 
 import (
 	"errors"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/adelowo/filer"
@@ -29,10 +28,8 @@ func NewMimeTypeValidator(mimeTypes []string) *MimeTypeValidator {
 //Currrently, the mimetype of the file is gotten by through the DetectContentType
 //function in net/http.
 func (mime *MimeTypeValidator) Validate(f filer.File) (bool, error) {
-
-	buf, err := ioutil.ReadAll(f)
-
-	if err != nil {
+	buf := make([]byte, 513)
+	if _, err := f.Read(buf[0:512]); err != nil {
 		return false, err
 	}
 


### PR DESCRIPTION
Detecting a mimetype needs at most the first 512 bytes of the document not the entire byes. This PR fixes that for the MimeTYpeValidator since it was reading everything into memory which would reduce performance for large files and aside perf issues, it didn't get used (only `buf[:512]` gets used not the entire buffer)